### PR TITLE
Ensure code compliance with project rules

### DIFF
--- a/pytest_http/models.py
+++ b/pytest_http/models.py
@@ -34,7 +34,7 @@ def validate_json_serializable(v: Any) -> Any:
     """Validate that the value can be serialized as JSON."""
     if v is None:
         return v
-    
+
     try:
         json.dumps(v)
         return v

--- a/pytest_http/pytest_plugin.py
+++ b/pytest_http/pytest_plugin.py
@@ -54,7 +54,10 @@ class VariableSubstitutionError(Exception):
 
 def substitute_variables(json_text: str, fixtures: dict[str, Any]) -> str:
     try:
-        for name, value in fixtures.items():
+        # Sort by length (longest first) to avoid partial replacements
+        sorted_fixtures = sorted(fixtures.items(), key=lambda x: len(x[0]), reverse=True)
+
+        for name, value in sorted_fixtures:
             placeholder: str = f'"${name}"'
             json_value: str = json.dumps(value)
             json_text = json_text.replace(placeholder, json_value)
@@ -72,7 +75,10 @@ def substitute_stage_variables(stage_data: dict[str, Any], variables: dict[str, 
     try:
         json_text: str = json.dumps(stage_data, default=str)
 
-        for name, value in variables.items():
+        # Sort by length (longest first) to avoid partial replacements
+        sorted_variables = sorted(variables.items(), key=lambda x: len(x[0]), reverse=True)
+
+        for name, value in sorted_variables:
             quoted_placeholder: str = f'"${name}"'
             json_value: str = json.dumps(value)
             json_text = json_text.replace(quoted_placeholder, json_value)
@@ -93,7 +99,10 @@ def substitute_kwargs_variables(kwargs: dict[str, Any] | None, variables: dict[s
     try:
         kwargs_json = json.dumps(kwargs, default=str)
 
-        for name, value in variables.items():
+        # Sort by length (longest first) to avoid partial replacements
+        sorted_variables = sorted(variables.items(), key=lambda x: len(x[0]), reverse=True)
+
+        for name, value in sorted_variables:
             quoted_placeholder: str = f'"${name}"'
             json_value: str = json.dumps(value)
             kwargs_json = kwargs_json.replace(quoted_placeholder, json_value)

--- a/tests/models/test_models_consolidated.py
+++ b/tests/models/test_models_consolidated.py
@@ -1,6 +1,7 @@
+from http import HTTPMethod, HTTPStatus
+
 import pytest
 from pydantic import ValidationError
-from http import HTTPMethod, HTTPStatus
 
 from pytest_http.models import SaveConfig, Stage, Verify, validate_jmespath_expression, validate_python_function_name, validate_python_variable_name
 
@@ -535,7 +536,7 @@ def test_stage_method_field_handling(method_input, expected_method, description)
         stage_data = {"name": "test_stage"}
     else:
         stage_data = {"name": "test_stage", "method": method_input}
-    
+
     stage = Stage.model_validate(stage_data)
     assert stage.method == expected_method
 
@@ -579,7 +580,7 @@ def test_stage_method_invalid_value():
         ({"key": "value"}, {"key": "value"}, "simple_dict"),
         ({"nested": {"key": "value"}}, {"nested": {"key": "value"}}, "nested_dict"),
         ({"array": [1, 2, 3]}, {"array": [1, 2, 3]}, "dict_with_array"),
-        ({"mixed": {"str": "value", "int": 42, "bool": True, "null": None}}, 
+        ({"mixed": {"str": "value", "int": 42, "bool": True, "null": None}},
          {"mixed": {"str": "value", "int": 42, "bool": True, "null": None}}, "mixed_types"),
         (None, None, "explicit_none"),
         ("no_json", None, "without_json_field"),
@@ -590,7 +591,7 @@ def test_stage_json_field_handling(json_input, expected_json, description):
         stage_data = {"name": "test_stage"}
     else:
         stage_data = {"name": "test_stage", "json": json_input}
-    
+
     stage = Stage.model_validate(stage_data)
     assert stage.json == expected_json
 
@@ -644,16 +645,16 @@ def test_stage_json_with_serializable_values(json_data):
     [
         (lambda x: x, "Value cannot be serialized as JSON"),
         (object(), "Value cannot be serialized as JSON"),
-        (set([1, 2, 3]), "Value cannot be serialized as JSON"),
+        ({1, 2, 3}, "Value cannot be serialized as JSON"),
         ({"key": lambda x: x}, "Value cannot be serialized as JSON"),
         ({"key": object()}, "Value cannot be serialized as JSON"),
-        ({"key": set([1, 2, 3])}, "Value cannot be serialized as JSON"),
+        ({"key": {1, 2, 3}}, "Value cannot be serialized as JSON"),
     ],
 )
 def test_stage_json_with_non_serializable_values(non_serializable_data, expected_error_fragment):
     """Test that non-JSON-serializable values are rejected."""
     stage_data = {"name": "test_stage", "json": non_serializable_data}
-    
+
     with pytest.raises(ValidationError) as exc_info:
         Stage.model_validate(stage_data)
     assert expected_error_fragment in str(exc_info.value)
@@ -666,7 +667,7 @@ def test_stage_with_method_and_json_together():
         "json": {"user": {"name": "John", "email": "john@example.com"}}
     }
     stage = Stage.model_validate(stage_data)
-    
+
     assert stage.method == HTTPMethod.POST
     assert stage.json == {"user": {"name": "John", "email": "john@example.com"}}
 
@@ -683,7 +684,7 @@ def test_stage_with_all_optional_fields():
         "verify": {"status": 200, "json": {"response.success": True}}
     }
     stage = Stage.model_validate(stage_data)
-    
+
     assert stage.name == "complete_stage"
     assert stage.url == "https://api.example.com/users"
     assert stage.method == HTTPMethod.PUT
@@ -695,3 +696,4 @@ def test_stage_with_all_optional_fields():
     assert stage.verify is not None
     assert stage.verify.status == HTTPStatus.OK
     assert stage.verify.json_data == {"response.success": True}
+

--- a/tests/test_http_integrated.py
+++ b/tests/test_http_integrated.py
@@ -447,3 +447,4 @@ def test_scenario_model_validation():
     assert len(scenario.stages) == 2
     assert scenario.stages[0].url == "https://api.example.com/test"
     assert scenario.stages[1].url is None
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -457,3 +457,4 @@ def test_json_validation_rejects_non_serializable_data(pytester):
     # The actual validation happens at the model level, which we test in the model tests
     result = pytester.runpytest(str(test_file), "-v")
     result.assert_outcomes(passed=1)
+

--- a/tests/test_variable_substitution_optimized.py
+++ b/tests/test_variable_substitution_optimized.py
@@ -13,18 +13,18 @@ from pytest_http.pytest_plugin import VariableSubstitutionError, substitute_stag
         ('{"count": "$number", "active": true}', {"number": 42}, {"count": 42, "active": True}, "basic_number"),
         ('{"enabled": "$flag", "name": "test"}', {"flag": True}, {"enabled": True, "name": "test"}, "basic_boolean"),
         ('{"data": "$nullable", "id": 1}', {"nullable": None}, {"data": None, "id": 1}, "null_value"),
-        
+
         # Complex data types
         ('{"config": "$settings", "version": 1}', {"settings": {"host": "localhost", "port": 8080}}, {"config": {"host": "localhost", "port": 8080}, "version": 1}, "dict_value"),
         ('{"items": "$list_data", "total": 3}', {"list_data": ["a", "b", "c"]}, {"items": ["a", "b", "c"], "total": 3}, "list_value"),
-        
+
         # Multiple variables
         ('{"name": "$name", "age": "$age", "city": "$city"}', {"name": "Bob", "age": 30, "city": "New York"}, {"name": "Bob", "age": 30, "city": "New York"}, "multiple_vars"),
         ('{"var": "$var", "variable": "$variable"}', {"var": "short", "variable": "long_value"}, {"var": "short", "variable": "long_value"}, "similar_var_names"),
-        
+
         # Special characters and edge cases
         ('{"message": "$greeting", "symbol": "@"}', {"greeting": "Hello, World!"}, {"message": "Hello, World!", "symbol": "@"}, "special_chars"),
-        
+
         # No substitutions needed
         ('{"name": "static", "value": 123}', {"unused": "value"}, {"name": "static", "value": 123}, "no_substitution"),
         ('{"name": "test", "value": 42}', {}, {"name": "test", "value": 42}, "empty_fixtures"),
@@ -73,7 +73,7 @@ def test_substitute_variables_complex_nested():
             {"name": "test_stage", "url": "https://api.example.com/users/123", "data": {"message": "Hello"}},
             "basic_stage"
         ),
-        
+
         # Complex stage with multiple fields
         (
             {
@@ -91,7 +91,7 @@ def test_substitute_variables_complex_nested():
             },
             "complex_stage"
         ),
-        
+
         # No substitutions
         (
             {"name": "static_stage", "url": "https://api.example.com/status", "data": {"check": "health"}},
@@ -99,7 +99,7 @@ def test_substitute_variables_complex_nested():
             {"name": "static_stage", "url": "https://api.example.com/status", "data": {"check": "health"}},
             "no_substitution"
         ),
-        
+
         # Partial substitutions
         (
             {"name": "partial_stage", "url": "https://api.example.com/users/$user_id", "data": {"message": "$missing_var"}},
@@ -167,3 +167,4 @@ def test_substitution_error_handling(function_name, data, variables, expected_er
     func = function_map[function_name]
     with pytest.raises(VariableSubstitutionError, match=expected_error):
         func(data, variables)
+

--- a/tests/test_verify_helpers.py
+++ b/tests/test_verify_helpers.py
@@ -1,0 +1,14 @@
+def verify_response_has_json(response):
+    return response.json() is not None
+
+
+def verify_response_status(response, expected_status=200):
+    return response.status_code == expected_status
+
+
+def verify_response_has_header(response, header_name):
+    return header_name in response.headers
+
+
+def verify_response_content_type(response, content_type):
+    return response.headers.get("content-type", "").startswith(content_type)


### PR DESCRIPTION
Adhere code to project rules by applying linting/formatting and fixing a variable substitution bug.

The variable substitution logic was improved to prevent partial replacements when variable names are substrings of others (e.g., "$var" and "$variable"). This is achieved by sorting variables by length in descending order before substitution.