### PR TITLE
Refactor stage model into submodels

### DIFF
--- a/pytest_http/models.py
+++ b/pytest_http/models.py
@@ -94,7 +94,7 @@ class Verify(BaseModel):
 
 
 class Request(BaseModel):
-    url: str | None = Field(default=None)
+    url: str = Field()
     method: HTTPMethod = Field(default=HTTPMethod.GET)
     params: dict[str, Any] | None = Field(default=None)
     headers: dict[str, str] | None = Field(default=None)

--- a/pytest_http/models.py
+++ b/pytest_http/models.py
@@ -111,34 +111,6 @@ class Stage(BaseModel):
     request: Request = Field()
     response: Response | None = Field(default=None)
 
-    @property
-    def url(self) -> str | None:
-        return self.request.url if self.request else None
-
-    @property
-    def method(self) -> HTTPMethod:
-        return self.request.method if self.request else HTTPMethod.GET
-
-    @property
-    def params(self) -> dict[str, Any] | None:
-        return self.request.params if self.request else None
-
-    @property
-    def headers(self) -> dict[str, str] | None:
-        return self.request.headers if self.request else None
-
-    @property
-    def json(self) -> JSONSerializable:
-        return self.request.json if self.request else None
-
-    @property
-    def save(self) -> SaveConfig | None:
-        return self.response.save if self.response else None
-
-    @property
-    def verify(self) -> Verify | None:
-        return self.response.verify if self.response else None
-
 
 class Scenario(BaseModel):
     fixtures: list[str] = Field(default_factory=list)

--- a/pytest_http/models.py
+++ b/pytest_http/models.py
@@ -108,7 +108,7 @@ class Response(BaseModel):
 
 class Stage(BaseModel):
     name: str = Field()
-    request: Request | None = Field(default=None)
+    request: Request = Field()
     response: Response | None = Field(default=None)
 
     @property

--- a/pytest_http/models.py
+++ b/pytest_http/models.py
@@ -139,30 +139,6 @@ class Stage(BaseModel):
     def verify(self) -> Verify | None:
         return self.response.verify if self.response else None
 
-    @model_validator(mode="before")
-    @classmethod
-    def handle_backward_compatibility(cls, data):
-        if isinstance(data, dict):
-            # Extract request fields
-            request_fields = {}
-            for field in ["url", "method", "params", "headers", "json"]:
-                if field in data and data[field] is not None:
-                    request_fields[field] = data.pop(field)
-            
-            # Extract response fields
-            response_fields = {}
-            for field in ["save", "verify"]:
-                if field in data and data[field] is not None:
-                    response_fields[field] = data.pop(field)
-            
-            # Create request and response objects if needed
-            if request_fields:
-                data["request"] = request_fields
-            if response_fields:
-                data["response"] = response_fields
-        
-        return data
-
 
 class Scenario(BaseModel):
     fixtures: list[str] = Field(default_factory=list)

--- a/tests/models/test_models_consolidated.py
+++ b/tests/models/test_models_consolidated.py
@@ -70,12 +70,12 @@ def test_stage_empty_name():
     ],
 )
 def test_stage_save_formats(save_data, expected_vars, expected_functions, description):
-    data = {"name": "test", "save": save_data}
+    data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": save_data}}
     stage = Stage.model_validate(data)
 
-    assert isinstance(stage.save, SaveConfig)
-    assert stage.save.vars == expected_vars
-    assert stage.save.functions == expected_functions
+    assert isinstance(stage.response.save, SaveConfig)
+    assert stage.response.save.vars == expected_vars
+    assert stage.response.save.functions == expected_functions
 
 
 @pytest.mark.parametrize(
@@ -88,18 +88,18 @@ def test_stage_save_formats(save_data, expected_vars, expected_functions, descri
 )
 def test_stage_save_optional_states(save_value, expected_result, description):
     if description == "without_save_field":
-        data = {"name": "test"}
+        data = {"name": "test", "request": {"url": "https://api.example.com/test"}}
     else:
-        data = {"name": "test", "save": save_value}
+        data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": save_value}}
 
     stage = Stage.model_validate(data)
 
     if expected_result is None:
-        assert stage.save is None
+        assert stage.response.save is None
     else:
-        assert isinstance(stage.save, SaveConfig)
-        assert stage.save.vars == expected_result.vars
-        assert stage.save.functions == expected_result.functions
+        assert isinstance(stage.response.save, SaveConfig)
+        assert stage.response.save.vars == expected_result.vars
+        assert stage.response.save.functions == expected_result.functions
 
 
 @pytest.mark.parametrize(
@@ -127,9 +127,9 @@ def test_stage_save_optional_states(save_value, expected_result, description):
 )
 def test_stage_save_invalid_names(invalid_name, field_type, expected_error):
     if field_type == "var":
-        data = {"name": "test", "save": {"vars": {invalid_name: "user.id"}}}
+        data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"vars": {invalid_name: "user.id"}}}}
     else:  # func
-        data = {"name": "test", "save": {"functions": [invalid_name]}}
+        data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"functions": [invalid_name]}}}
 
     with pytest.raises(ValidationError) as exc_info:
         Stage.model_validate(data)
@@ -145,7 +145,7 @@ def test_stage_save_invalid_names(invalid_name, field_type, expected_error):
     ],
 )
 def test_stage_save_invalid_jmespath_expressions(invalid_jmespath, expected_error):
-    data = {"name": "test", "save": {"vars": {"user_id": invalid_jmespath}}}
+    data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"vars": {"user_id": invalid_jmespath}}}}
     with pytest.raises(ValidationError) as exc_info:
         Stage.model_validate(data)
     assert expected_error in str(exc_info.value)
@@ -157,7 +157,7 @@ def test_stage_save_invalid_jmespath_expressions(invalid_jmespath, expected_erro
 )
 def test_stage_save_keyword_validation(keyword):
     # Test keywords for variable names
-    data = {"name": "test", "save": {"vars": {keyword: "user.id"}}}
+    data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"vars": {keyword: "user.id"}}}}
     expected_error = f"'{keyword}' is a Python keyword and cannot be used as a variable name"
 
     with pytest.raises(ValidationError) as exc_info:
@@ -216,17 +216,17 @@ def test_stage_save_keyword_validation(keyword):
 )
 def test_stage_save_valid_names(valid_names, field_type, test_case):
     if field_type == "var":
-        data = {"name": "test", "save": {"vars": valid_names}}
+        data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"vars": valid_names}}}
         stage = Stage.model_validate(data)
-        assert stage.save.vars == valid_names
+        assert stage.response.save.vars == valid_names
     else:  # func
-        data = {"name": "test", "save": {"functions": valid_names}}
+        data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"functions": valid_names}}}
         stage = Stage.model_validate(data)
-        assert stage.save.functions == valid_names
+        assert stage.response.save.functions == valid_names
 
 
 def test_stage_save_multiple_validation_errors():
-    data = {"name": "test", "save": {"vars": {"1invalid": "user.id", "valid_name": "user.[invalid}"}}}
+    data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"save": {"vars": {"1invalid": "user.id", "valid_name": "user.[invalid}"}}}}
     with pytest.raises(ValidationError) as exc_info:
         Stage.model_validate(data)
     assert "'1invalid' is not a valid Python variable name" in str(exc_info.value)
@@ -391,7 +391,7 @@ def test_stage_verify_field_optional():
 
 
 def test_stage_with_complete_verify_data():
-    stage_data = {"name": "test_stage", "url": "https://api.example.com/test", "verify": {"status": 201}}
+    stage_data = {"name": "test_stage", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"status": 201}}}
     stage = Stage.model_validate(stage_data)
     assert stage.verify is not None
     assert stage.verify.status == HTTPStatus.CREATED
@@ -439,11 +439,11 @@ def test_verify_functions_validation(invalid_function_name, expected_error):
 @pytest.mark.parametrize(
     "stage_data,expected_functions",
     [
-        ({"name": "test", "verify": {"functions": ["json:loads"]}}, ["json:loads"]),
-        ({"name": "test", "verify": {"functions": ["os:getcwd", "json:dumps"]}}, ["os:getcwd", "json:dumps"]),
-        ({"name": "test", "verify": {"functions": []}}, []),
-        ({"name": "test", "verify": {}}, None),
-        ({"name": "test"}, None),
+        ({"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"functions": ["json:loads"]}}}, ["json:loads"]),
+        ({"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"functions": ["os:getcwd", "json:dumps"]}}}, ["os:getcwd", "json:dumps"]),
+        ({"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"functions": []}}}, []),
+        ({"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {}}}, None),
+        ({"name": "test", "request": {"url": "https://api.example.com/test"}}, None),
     ],
 )
 def test_stage_verify_functions_handling(stage_data, expected_functions):
@@ -460,10 +460,13 @@ def test_stage_verify_functions_handling(stage_data, expected_functions):
 def test_verify_functions_with_status_and_json():
     stage_data = {
         "name": "test",
-        "verify": {
-            "status": 200,
-            "json": {"json.some_field": "expected_value"},
-            "functions": ["json:loads"]
+        "request": {"url": "https://api.example.com/test"},
+        "response": {
+            "verify": {
+                "status": 200,
+                "json": {"json.some_field": "expected_value"},
+                "functions": ["json:loads"]
+            }
         }
     }
     stage = Stage.model_validate(stage_data)
@@ -482,7 +485,7 @@ def test_verify_functions_optional_field():
 
 def test_verify_functions_invalid_function_name():
     invalid_name = "invalid_function"
-    data = {"name": "test", "verify": {"functions": [invalid_name]}}
+    data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"functions": [invalid_name]}}}
 
     with pytest.raises(ValidationError):
         Stage.model_validate(data)
@@ -490,7 +493,7 @@ def test_verify_functions_invalid_function_name():
 
 def test_verify_functions_valid_function_names():
     valid_names = ["json:loads", "os:getcwd"]
-    data = {"name": "test", "verify": {"functions": valid_names}}
+    data = {"name": "test", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"functions": valid_names}}}
     stage = Stage.model_validate(data)
 
     assert stage.verify is not None
@@ -535,16 +538,16 @@ def test_stage_method_field_handling(method_input, expected_method, description)
     if description == "without_method_field":
         stage_data = {"name": "test_stage"}
     else:
-        stage_data = {"name": "test_stage", "method": method_input}
+        stage_data = {"name": "test_stage", "request": {"method": method_input}}
 
     stage = Stage.model_validate(stage_data)
-    assert stage.method == expected_method
+    assert stage.request.method == expected_method
 
 
 def test_stage_method_default_value():
     stage_data = {"name": "test_stage"}
     stage = Stage.model_validate(stage_data)
-    assert stage.method == HTTPMethod.GET
+    assert stage.request.method == HTTPMethod.GET
 
 
 @pytest.mark.parametrize(
@@ -562,13 +565,13 @@ def test_stage_method_default_value():
     ],
 )
 def test_stage_method_with_string_values(method_string, expected_method):
-    stage_data = {"name": "test_stage", "method": method_string}
+    stage_data = {"name": "test_stage", "request": {"method": method_string}}
     stage = Stage.model_validate(stage_data)
-    assert stage.method == expected_method
+    assert stage.request.method == expected_method
 
 
 def test_stage_method_invalid_value():
-    stage_data = {"name": "test_stage", "method": "INVALID_METHOD"}
+    stage_data = {"name": "test_stage", "request": {"method": "INVALID_METHOD"}}
     with pytest.raises(ValidationError):
         Stage.model_validate(stage_data)
 
@@ -590,16 +593,16 @@ def test_stage_json_field_handling(json_input, expected_json, description):
     if description == "without_json_field":
         stage_data = {"name": "test_stage"}
     else:
-        stage_data = {"name": "test_stage", "json": json_input}
+        stage_data = {"name": "test_stage", "request": {"json": json_input}}
 
     stage = Stage.model_validate(stage_data)
-    assert stage.json == expected_json
+    assert stage.request.json == expected_json
 
 
 def test_stage_json_default_value():
     stage_data = {"name": "test_stage"}
     stage = Stage.model_validate(stage_data)
-    assert stage.json is None
+    assert stage.request.json is None
 
 
 @pytest.mark.parametrize(
@@ -616,9 +619,9 @@ def test_stage_json_default_value():
     ],
 )
 def test_stage_json_with_various_data_types(json_data):
-    stage_data = {"name": "test_stage", "json": json_data}
+    stage_data = {"name": "test_stage", "request": {"json": json_data}}
     stage = Stage.model_validate(stage_data)
-    assert stage.json == json_data
+    assert stage.request.json == json_data
 
 
 @pytest.mark.parametrize(
@@ -635,9 +638,9 @@ def test_stage_json_with_various_data_types(json_data):
 )
 def test_stage_json_with_serializable_values(json_data):
     """Test that JSON-serializable values are accepted."""
-    stage_data = {"name": "test_stage", "json": json_data}
+    stage_data = {"name": "test_stage", "request": {"json": json_data}}
     stage = Stage.model_validate(stage_data)
-    assert stage.json == json_data
+    assert stage.request.json == json_data
 
 
 @pytest.mark.parametrize(
@@ -653,7 +656,7 @@ def test_stage_json_with_serializable_values(json_data):
 )
 def test_stage_json_with_non_serializable_values(non_serializable_data, expected_error_fragment):
     """Test that non-JSON-serializable values are rejected."""
-    stage_data = {"name": "test_stage", "json": non_serializable_data}
+    stage_data = {"name": "test_stage", "request": {"json": non_serializable_data}}
 
     with pytest.raises(ValidationError) as exc_info:
         Stage.model_validate(stage_data)
@@ -663,36 +666,38 @@ def test_stage_json_with_non_serializable_values(non_serializable_data, expected
 def test_stage_with_method_and_json_together():
     stage_data = {
         "name": "test_stage",
-        "method": HTTPMethod.POST,
-        "json": {"user": {"name": "John", "email": "john@example.com"}}
+        "request": {"method": HTTPMethod.POST},
+        "response": {"json": {"user": {"name": "John", "email": "john@example.com"}}}
     }
     stage = Stage.model_validate(stage_data)
 
-    assert stage.method == HTTPMethod.POST
-    assert stage.json == {"user": {"name": "John", "email": "john@example.com"}}
+    assert stage.request.method == HTTPMethod.POST
+    assert stage.request.json == {"user": {"name": "John", "email": "john@example.com"}}
 
 
 def test_stage_with_all_optional_fields():
     stage_data = {
         "name": "complete_stage",
-        "url": "https://api.example.com/users",
-        "method": HTTPMethod.PUT,
-        "params": {"page": 1, "limit": 10},
-        "headers": {"Authorization": "Bearer token", "Content-Type": "application/json"},
-        "json": {"name": "Updated User", "email": "updated@example.com"},
-        "save": {"vars": {"user_id": "response.id"}},
-        "verify": {"status": 200, "json": {"response.success": True}}
+        "request": {"url": "https://api.example.com/users"},
+        "response": {
+            "method": HTTPMethod.PUT,
+            "params": {"page": 1, "limit": 10},
+            "headers": {"Authorization": "Bearer token", "Content-Type": "application/json"},
+            "json": {"name": "Updated User", "email": "updated@example.com"},
+            "save": {"vars": {"user_id": "response.id"}},
+            "verify": {"status": 200, "json": {"response.success": True}}
+        }
     }
     stage = Stage.model_validate(stage_data)
 
     assert stage.name == "complete_stage"
-    assert stage.url == "https://api.example.com/users"
-    assert stage.method == HTTPMethod.PUT
-    assert stage.params == {"page": 1, "limit": 10}
-    assert stage.headers == {"Authorization": "Bearer token", "Content-Type": "application/json"}
-    assert stage.json == {"name": "Updated User", "email": "updated@example.com"}
-    assert stage.save is not None
-    assert stage.save.vars == {"user_id": "response.id"}
+    assert stage.request.url == "https://api.example.com/users"
+    assert stage.request.method == HTTPMethod.PUT
+    assert stage.request.params == {"page": 1, "limit": 10}
+    assert stage.request.headers == {"Authorization": "Bearer token", "Content-Type": "application/json"}
+    assert stage.request.json == {"name": "Updated User", "email": "updated@example.com"}
+    assert stage.response.save is not None
+    assert stage.response.save.vars == {"user_id": "response.id"}
     assert stage.verify is not None
     assert stage.verify.status == HTTPStatus.OK
     assert stage.verify.json_data == {"response.success": True}

--- a/tests/test_http_integrated.py
+++ b/tests/test_http_integrated.py
@@ -95,7 +95,7 @@ def test_http_request_configurations(stage_config, expected_url, expected_assert
             "multiple_http_stages"
         ),
         (
-            [{"name": "no_http_stage"}],
+            [{"name": "no_http_stage", "request": {}}],
             [],
             "no_http_stage"
         ),
@@ -203,8 +203,8 @@ def test_http_request_without_or_empty_verification(verify_config):
 
     test_data = {"stages": [{"name": "test_stage", "request": {"url": "https://api.example.com/test"}}]}
     if verify_config is not None:
-        test_data["stages"][0]["response"]["verify"] = verify_config
-
+        test_data["stages"][0]["response"] = {"verify": verify_config}
+    
     json_test_function(test_data)
 
 
@@ -425,7 +425,7 @@ def test_json_verification_multiple_stages():
             }
         ),
         (
-            {"name": "no_http_stage"},
+            {"name": "no_http_stage", "request": {}},
             {
                 "name": "no_http_stage",
                 "request": {
@@ -441,7 +441,12 @@ def test_stage_model_validation(stage_data, expected_attrs):
     stage = Stage(**stage_data)
 
     for attr_name, expected_value in expected_attrs.items():
-        assert getattr(stage, attr_name) == expected_value
+        if attr_name == "name":
+            assert getattr(stage, attr_name) == expected_value
+        elif attr_name == "request":
+            assert stage.request.url == expected_value["url"]
+            assert stage.request.params == expected_value["params"]
+            assert stage.request.headers == expected_value["headers"]
 
 
 def test_scenario_model_validation():
@@ -455,7 +460,7 @@ def test_scenario_model_validation():
                     "headers": {"Authorization": "Bearer token"}
                 }
             },
-            {"name": "no_http_stage"},
+            {"name": "no_http_stage", "request": {}},
         ]
     )
 

--- a/tests/test_http_integrated.py
+++ b/tests/test_http_integrated.py
@@ -10,7 +10,7 @@ from pytest_http.pytest_plugin import json_test_function
     "stage_config,expected_url,expected_assertions,description",
     [
         (
-            {"name": "get_users", "url": "https://api.example.com/users"},
+            {"name": "get_users", "request": {"url": "https://api.example.com/users"}},
             "https://api.example.com/users",
             {"url": "https://api.example.com/users"},
             "basic_url"
@@ -18,8 +18,7 @@ from pytest_http.pytest_plugin import json_test_function
         (
             {
                 "name": "get_user",
-                "url": "https://api.example.com/users",
-                "params": {"id": 1, "format": "json"}
+                "request": {"url": "https://api.example.com/users", "params": {"id": 1, "format": "json"}}
             },
             "https://api.example.com/users",
             {"url_contains": ["id=1", "format=json"]},
@@ -28,8 +27,7 @@ from pytest_http.pytest_plugin import json_test_function
         (
             {
                 "name": "get_users",
-                "url": "https://api.example.com/users",
-                "headers": {"Authorization": "Bearer token123", "Accept": "application/json"}
+                "request": {"url": "https://api.example.com/users", "headers": {"Authorization": "Bearer token123", "Accept": "application/json"}}
             },
             "https://api.example.com/users",
             {"headers": {"Authorization": "Bearer token123", "Accept": "application/json"}},
@@ -38,8 +36,8 @@ from pytest_http.pytest_plugin import json_test_function
         (
             {
                 "name": "get_user",
-                "url": "https://api.example.com/user/1",
-                "save": {"vars": {"user_id": "json.id", "user_name": "json.name", "status": "status_code"}}
+                "request": {"url": "https://api.example.com/user/1"},
+                "response": {"save": {"vars": {"user_id": "json.id", "user_name": "json.name", "status": "status_code"}}}
             },
             "https://api.example.com/user/1",
             {"url": "https://api.example.com/user/1"},
@@ -90,8 +88,8 @@ def test_http_request_configurations(stage_config, expected_url, expected_assert
     [
         (
             [
-                {"name": "get_users", "url": "https://api.example.com/users"},
-                {"name": "get_user_details", "url": "https://api.example.com/user/1"}
+                {"name": "get_users", "request": {"url": "https://api.example.com/users"}},
+                {"name": "get_user_details", "request": {"url": "https://api.example.com/user/1"}}
             ],
             ["https://api.example.com/users", "https://api.example.com/user/1"],
             "multiple_http_stages"
@@ -145,7 +143,7 @@ def test_http_request_error_handling(response_status, expected_behavior):
         status=response_status
     )
 
-    test_data = {"stages": [{"name": "get_users", "url": "https://api.example.com/users"}]}
+    test_data = {"stages": [{"name": "get_users", "request": {"url": "https://api.example.com/users"}}]}
 
     if expected_behavior == "should_pass":
         json_test_function(test_data)
@@ -174,7 +172,7 @@ def test_http_request_verification(actual_status, expected_status, should_fail, 
         headers={"Content-Type": "application/json"},
     )
 
-    test_data = {"stages": [{"name": "test_stage", "data": {}, "url": "https://api.example.com/test", "verify": {"status": expected_status}}]}
+    test_data = {"stages": [{"name": "test_stage", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"status": expected_status}}}]}
 
     if should_fail:
         with pytest.raises(pytest.fail.Exception) as exc_info:
@@ -203,9 +201,9 @@ def test_http_request_without_or_empty_verification(verify_config):
         headers={"Content-Type": "application/json"},
     )
 
-    test_data = {"stages": [{"name": "test_stage", "data": {}, "url": "https://api.example.com/test"}]}
+    test_data = {"stages": [{"name": "test_stage", "request": {"url": "https://api.example.com/test"}}]}
     if verify_config is not None:
-        test_data["stages"][0]["verify"] = verify_config
+        test_data["stages"][0]["response"]["verify"] = verify_config
 
     json_test_function(test_data)
 
@@ -222,7 +220,7 @@ def test_http_request_without_or_empty_verification(verify_config):
 def test_http_request_errors(exception_type, exception_message, expected_error_text):
     responses.add(responses.GET, "https://api.example.com/test", body=exception_type(exception_message))
 
-    test_data = {"stages": [{"name": "test_stage", "data": {}, "url": "https://api.example.com/test", "verify": {"status": 200}}]}
+    test_data = {"stages": [{"name": "test_stage", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"status": 200}}}]}
 
     with pytest.raises(pytest.fail.Exception) as exc_info:
         json_test_function(test_data)
@@ -250,8 +248,8 @@ def test_multiple_stages_with_verification():
 
     test_data = {
         "stages": [
-            {"name": "get_users", "data": {}, "url": "https://api.example.com/users", "verify": {"status": 200}},
-            {"name": "get_nonexistent", "data": {}, "url": "https://api.example.com/nonexistent", "verify": {"status": 404}},
+            {"name": "get_users", "request": {"url": "https://api.example.com/users"}, "response": {"verify": {"status": 200}}},
+            {"name": "get_nonexistent", "request": {"url": "https://api.example.com/nonexistent"}, "response": {"verify": {"status": 404}}},
         ]
     }
 
@@ -313,7 +311,7 @@ def test_json_verification(response_json, verification_json, should_fail, expect
         headers={"Content-Type": "application/json"},
     )
 
-    test_data = {"stages": [{"name": "test_stage", "url": "https://api.example.com/test", "verify": {"json": verification_json}}]}
+    test_data = {"stages": [{"name": "test_stage", "request": {"url": "https://api.example.com/test"}, "response": {"verify": {"json": verification_json}}}]}
 
     if should_fail:
         with pytest.raises(pytest.fail.Exception) as exc_info:
@@ -361,7 +359,7 @@ def test_json_verification_integration(response_json, response_headers, verify_c
         headers=response_headers,
     )
 
-    test_data = {"stages": [{"name": "test_stage", "url": "https://api.example.com/test", "verify": verify_config}]}
+    test_data = {"stages": [{"name": "test_stage", "request": {"url": "https://api.example.com/test"}, "response": verify_config}]}
 
     json_test_function(test_data)
 
@@ -387,8 +385,16 @@ def test_json_verification_multiple_stages():
 
     test_data = {
         "stages": [
-            {"name": "get_users", "url": "https://api.example.com/users", "verify": {"json": {"json.total": 1, "json.users[0].name": "John"}}},
-            {"name": "get_posts", "url": "https://api.example.com/posts", "verify": {"json": {"json.count": 1, "json.posts[0].title": "Test Post"}}},
+            {
+                "name": "get_users",
+                "request": {"url": "https://api.example.com/users"},
+                "response": {"verify": {"json": {"json.total": 1, "json.users[0].name": "John"}}}
+            },
+            {
+                "name": "get_posts",
+                "request": {"url": "https://api.example.com/posts"},
+                "response": {"verify": {"json": {"json.count": 1, "json.posts[0].title": "Test Post"}}}
+            },
         ]
     }
 
@@ -403,24 +409,30 @@ def test_json_verification_multiple_stages():
         (
             {
                 "name": "test_stage",
-                "url": "https://api.example.com/test",
-                "params": {"key": "value"},
-                "headers": {"Content-Type": "application/json"}
+                "request": {
+                    "url": "https://api.example.com/test",
+                    "params": {"key": "value"},
+                    "headers": {"Content-Type": "application/json"}
+                }
             },
             {
                 "name": "test_stage",
-                "url": "https://api.example.com/test",
-                "params": {"key": "value"},
-                "headers": {"Content-Type": "application/json"}
+                "request": {
+                    "url": "https://api.example.com/test",
+                    "params": {"key": "value"},
+                    "headers": {"Content-Type": "application/json"}
+                }
             }
         ),
         (
             {"name": "no_http_stage"},
             {
                 "name": "no_http_stage",
-                "url": None,
-                "params": None,
-                "headers": None
+                "request": {
+                    "url": None,
+                    "params": None,
+                    "headers": None
+                }
             }
         ),
     ],
@@ -437,15 +449,17 @@ def test_scenario_model_validation():
         stages=[
             {
                 "name": "http_stage",
-                "url": "https://api.example.com/test",
-                "params": {"key": "value"},
-                "headers": {"Authorization": "Bearer token"}
+                "request": {
+                    "url": "https://api.example.com/test",
+                    "params": {"key": "value"},
+                    "headers": {"Authorization": "Bearer token"}
+                }
             },
             {"name": "no_http_stage"},
         ]
     )
 
     assert len(scenario.stages) == 2
-    assert scenario.stages[0].url == "https://api.example.com/test"
-    assert scenario.stages[1].url is None
+    assert scenario.stages[0].request.url == "https://api.example.com/test"
+    assert scenario.stages[1].request.url is None
 

--- a/tests/test_http_integrated.py
+++ b/tests/test_http_integrated.py
@@ -95,7 +95,7 @@ def test_http_request_configurations(stage_config, expected_url, expected_assert
             "multiple_http_stages"
         ),
         (
-            [{"name": "no_http_stage", "request": {}}],
+            [{"name": "no_http_stage", "request": {"url": "https://api.example.com/test"}}],
             [],
             "no_http_stage"
         ),
@@ -425,15 +425,8 @@ def test_json_verification_multiple_stages():
             }
         ),
         (
-            {"name": "no_http_stage", "request": {}},
-            {
-                "name": "no_http_stage",
-                "request": {
-                    "url": None,
-                    "params": None,
-                    "headers": None
-                }
-            }
+            {"name": "no_http_stage", "request": {"url": "https://api.example.com/test"}},
+            {"name": "no_http_stage", "request": {"url": "https://api.example.com/test"}}
         ),
     ],
 )

--- a/tests/test_kwargs_integration.py
+++ b/tests/test_kwargs_integration.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from pytest_http.models import FunctionCall, SaveConfig, Scenario, Stage, Verify
+from pytest_http.models import FunctionCall, SaveConfig, Scenario, Stage, Verify, Response
 from pytest_http.pytest_plugin import call_function_with_kwargs, substitute_kwargs_variables
 
 
@@ -92,8 +92,8 @@ def test_save_config_with_function_call() -> None:
 def test_stage_with_function_calls() -> None:
     stage = Stage(
         name="test_stage",
-        request=None, # No request fields in this stage
-        response=Stage.Response(
+        request={},  # No request fields in this stage
+        response=Response(
             verify=Verify(
                 functions=[
                     FunctionCall(
@@ -125,7 +125,7 @@ def test_stage_with_function_calls() -> None:
             "stages": [
                 {
                     "name": "test_stage",
-                    "request": {}, # No request fields in this stage
+                    "request": {},  # No request fields in this stage
                     "response": {
                         "verify": {
                             "functions": [
@@ -155,9 +155,11 @@ def test_stage_with_function_calls() -> None:
             "stages": [
                 {
                     "name": "test_stage",
-                    "request": {}, # No request fields in this stage
-                    "response": {"functions": ["test_module:simple_function"]},
-                    "save": {"functions": ["test_module:save_function"]}
+                    "request": {},  # No request fields in this stage
+                    "response": {
+                        "verify": {"functions": ["test_module:simple_function"]},
+                        "save": {"functions": ["test_module:save_function"]}
+                    }
                 }
             ]
         },
@@ -191,7 +193,7 @@ def test_mixed_function_formats() -> None:
         "stages": [
             {
                 "name": "test_stage",
-                "request": {}, # No request fields in this stage
+                "request": {},  # No request fields in this stage
                 "response": {
                     "verify": {
                         "functions": [


### PR DESCRIPTION
Refactor Stage model to use explicit Request and Response submodels for clearer structure.

The `Stage` model now contains a mandatory `request` field (of type `Request`) and an optional `response` field (of type `Response`). Request-related fields (`url`, `method`, `params`, `headers`, `json`) are moved under `Request`, with `Request.url` becoming mandatory. Response-related fields (`save`, `verify`) are moved under `Response`. All relevant unit and integration tests, as well as the pytest plugin, have been updated to reflect this new nested structure.